### PR TITLE
Add suppport for HTML content on some fields of MarineEbsas CF

### DIFF
--- a/app/boot.js
+++ b/app/boot.js
@@ -18,6 +18,7 @@ require.config({
       'URIjs'               : 'libs/uri.js/src',
       'linqjs'              : 'libs/linqjs/linq.min',
       'leaflet'             : 'https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet',
+      'dompurify'           : 'https://cdn.jsdelivr.net/npm/dompurify@3.0.1/dist/purify.min',
       'jquery'              : 'libs/jquery/dist/jquery.min',
       'moment'              : 'libs/moment/moment',
       'leaflet-directive'   : 'js/libs/leaflet/angular-leaflet-directive',

--- a/app/css/bootstrap.css
+++ b/app/css/bootstrap.css
@@ -706,7 +706,6 @@ pre {
   margin: 0 0 9px;
   font-size: 12px;
   line-height: 1.42857143;
-  word-break: break-all;
   word-wrap: break-word;
   color: #333333;
   background-color: #f5f5f5;

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -62,6 +62,13 @@ float:none;
 .km-pre {
   	word-wrap: break-word; white-space: pre-wrap;
 }
+
+.km-rtl text-angular > [text-angular-toolbar] {
+	position: sticky;
+	top: 0.5rem;
+	z-index: 10;
+}
+
 label{
     margin-top:10px;
 }

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -59,10 +59,9 @@ float:none;
     border-radius: 3px;
   }
 
-.km-pre
-  {
-  	word-break: break-all; word-wrap: break-word; white-space: pre-wrap;
-  }
+.km-pre {
+  	word-wrap: break-word; white-space: pre-wrap;
+}
 label{
     margin-top:10px;
 }

--- a/app/directives/formats/forms/marine-ebsa-assessment.html
+++ b/app/directives/formats/forms/marine-ebsa-assessment.html
@@ -13,7 +13,9 @@
 		<br/>
 		<br/>
 
-		<div class="km-textbox-ml" ng-disabled="!assessment.selected" ng-model="assessment.justification" rows="8" locales="locales"></div>
+		<div km-rich-textbox ng-disabled="!assessment.selected" ng-model="assessment.justification" rows="8" locales="locales"
+			identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
+
 	</li>
 
 </ol>

--- a/app/directives/formats/forms/marine-ebsa-assessment.js
+++ b/app/directives/formats/forms/marine-ebsa-assessment.js
@@ -9,7 +9,9 @@ app.directive('marineEbsaAssessment', [ function () {
 		require : "?ngModel",
 		scope: {
 			binding : "=ngModel",
-			locales : "="
+			locales : "=",
+			onEditorFileUpload: "&?",
+			onEditorPaste: "&?"
 		},
 		link : function($scope, e, a, ngModelCtrl)
 		{

--- a/app/directives/formats/forms/marine-ebsa.html
+++ b/app/directives/formats/forms/marine-ebsa.html
@@ -66,7 +66,8 @@
 					<div class="col-md-12">
 						<div class="form-group">
 							<label class="control-label" for="areaIntroducion">Introduction of the area</label>
-							<div km-textbox-ml name="areaIntroducion" ng-model="document.areaIntroducion" rows="12" locales="document.header.languages" placeholder="example: this area..."></div>
+							<div km-rich-textbox name="areaIntroducion" ng-model="document.areaIntroducion" rows="12" locales="document.header.languages" placeholder="example: this area..."
+												 identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>
@@ -86,7 +87,8 @@
 					<div class="col-md-12">
 						<div class="form-group">
 							<label class="control-label" required for="location">Location</label>
-							<div km-textbox-ml name="location" ng-model="document.location" rows="4" locales="document.header.languages" placeholder="example: this area is located..."></div>
+							<div km-rich-textbox name="location" ng-model="document.location" rows="4" locales="document.header.languages" placeholder="example: this area is located..."
+												 identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>
@@ -103,7 +105,6 @@
 
 				<div class="row">
 					<div class="col-md-12">
-
 						<leaflet center="document.gisMapCenter" layers="gisLayer" scroll-wheel-zoom="false" ></leaflet>
 					</div>
 				</div>
@@ -114,7 +115,8 @@
 					<div class="col-md-12">
 						<div class="form-group">
 							<label class="control-label" for="areaDescription">Feature description of the area</label>
-							<div km-textbox-ml name="areaDescription" ng-model="document.areaDescription" rows="4" locales="document.header.languages"></div>
+							<div km-rich-textbox name="areaDescription" ng-model="document.areaDescription" rows="4" locales="document.header.languages"
+  								 identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>
@@ -123,7 +125,8 @@
 					<div class="col-md-12">
 						<div class="form-group">
 							<label class="control-label" for="areaConditions">Feature conditions and future outlook of the area</label>
-							<div km-textbox-ml name="areaConditions" ng-model="document.areaConditions" rows="4" locales="document.header.languages"></div>
+							<div km-rich-textbox name="areaConditions" ng-model="document.areaConditions" rows="4" locales="document.header.languages"
+								identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>
@@ -133,7 +136,8 @@
 					<div class="col-md-12">
 						<div class="form-group">
 							<label class="control-label" for="areaFeatures">Feature description of the area</label>
-							<div km-textbox-ml name="areaFeatures" ng-model="document.areaFeatures" rows="4" locales="document.header.languages"></div>
+							<div km-rich-textbox name="areaFeatures" ng-model="document.areaFeatures" rows="4" locales="document.header.languages"
+								identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>
@@ -163,7 +167,8 @@
 					<div class="col-md-12">
 						<div class="form-group">
 							<label class="control-label" name="referenceText">References</label>
-							<div km-textbox-ml name="referenceText" rows="4" ng-model="document.referenceText" locales="document.header.languages"></div>
+							<div km-rich-textbox name="referenceText" rows="4" ng-model="document.referenceText" locales="document.header.languages"
+								identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>
@@ -425,7 +430,8 @@
 						<div class="form-group">
 							<label class="control-label" name="additionalInformation">Additional Information</label>
 							<div class="help-block">Please use this field to provide any other relevant information that may not have been addressed elsewhere in the record.</div>
-							<div km-textbox-ml name="additionalInformation" rows="6" ng-model="document.relevantInformation" locales="document.header.languages"></div>
+							<div km-rich-textbox name="additionalInformation" rows="6" ng-model="document.relevantInformation" locales="document.header.languages"
+								identifier="document.header.identifier" on-file-upload="onEditorFileUpload(data)" on-paste="onEditorPaste(html)" ></div>
 						</div>
 					</div>
 				</div>

--- a/app/directives/formats/forms/marine-ebsa.html
+++ b/app/directives/formats/forms/marine-ebsa.html
@@ -176,7 +176,7 @@
 				<div class="row">
 					<div class="col-md-12">
 						<div class="form-group">
-							<label class="control-label" name="resources">CBD Recources</label>
+							<label class="control-label" name="resources">CBD Resources</label>
 							<div km-reference multiple name="resources" ng-model="document.resources" loader="loadRecords(identifier, 'resource')">
 								<div>
 									<div><strong>{{reference.title | lstring:'en'}}</strong></div>

--- a/app/directives/formats/views/marine-ebsa.html
+++ b/app/directives/formats/views/marine-ebsa.html
@@ -6,11 +6,11 @@
 		<legend>General Information</legend>
 		<div ng-show="document.summary">
 			<label>Summary</label>
-			<div class="km-value km-pre">{{document.summary | lstring:local}}</div>
+			<div class="km-value km-pre">{{document.summary | lstring:locale}}</div>
 		</div>
 		<div ng-show="document.areaIntroducion">
 			<label>Introduction of the area</label>
-			<div class="km-value km-pre">{{document.areaIntroducion | lstring:local}}</div>
+			<km-value-ml value="document.areaIntroducion" locales="locale" km-pre html></km-value-ml>
 		</div>
 	</div>
 
@@ -22,7 +22,7 @@
 		</div>
 		<div ng-show="document.location">
 			<label>Description of location</label>
-			<div class="km-value km-pre">{{document.location|lstring:locale}}</div>
+			<km-value-ml value="document.location" locales="locale" km-pre html></km-value-ml>
 		</div>
 
 		<div ng-show="document.gisFiles">
@@ -42,15 +42,15 @@
 		<legend>Area Details</legend>
 		<div ng-show="document.areaDescription">
 			<label>Feature description of the area</label>
-			<div class="km-value km-pre">{{document.areaDescription | lstring:local}}</div>
+			<km-value-ml value="document.areaDescription" locales="locale" km-pre html></km-value-ml>
 		</div>
 		<div ng-show="document.areaConditions">
-		<label>Feature conditions and future outlook of the area</label>
-		<div class="km-value km-pre">{{document.areaConditions | lstring:local}}</div>
+			<label>Feature conditions and future outlook of the area</label>
+			<km-value-ml value="document.areaConditions" locales="locale" km-pre html></km-value-ml>
 		</div>
 		<div ng-show="document.areaFeatures">
 			<label>Feature description of the area</label>
-			<div class="km-value km-pre">{{document.areaFeatures | lstring:local}}</div>
+			<km-value-ml value="document.areaFeatures" locales="locale" km-pre html></km-value-ml>
 		</div>
 		<div ng-show="document.countries">
 			<label>Related countries</label>
@@ -68,7 +68,7 @@
 	<div ng-show="document.referenceText">
 		<legend>References</legend>
 		<label>References</label>
-		<div class="km-value km-pre">{{document.referenceText | lstring:local}}</div>
+		<km-value-ml value="document.referenceText" locales="locale" km-pre html></km-value-ml>
 	</div>
 
 	<div ng-show="document.resources">
@@ -202,7 +202,7 @@
 					</div>
 					<div ng-show="document.recommendedToWorkshopByOthers">
 						<label>Details</label>
-						<div class="km-value">{{document.recommendedToWorkshopByOthers | lstring:local}}</div>
+						<div class="km-value">{{document.recommendedToWorkshopByOthers | lstring:locale}}</div>
 					</div>
 
 				</div>
@@ -243,7 +243,7 @@
 
 					<div ng-show="document.recommendedToAnyByOthers">
 						<label>Details</label>
-						<div class="km-value">{{document.recommendedToAnyByOthers | lstring:local}}</div>
+						<div class="km-value">{{document.recommendedToAnyByOthers | lstring:locale}}</div>
 					</div>
 
 				</div>
@@ -275,7 +275,7 @@
 			</div>
 			<div class="panel-body" ng-show="assessment.justification">
 				<label>Justification</label>
-				<div class="km-value km-pre">{{assessment.justification|lstring:locale}}</div>
+				<km-value-ml value="assessment.justification" locales="locale" km-pre html></km-value-ml>
 			</div>
 		</div>
 
@@ -286,7 +286,7 @@
 
 		<div ng-show="document.relevantInformation">
 			<label>Additional Information</label>
-			<div class="km-value" ng-bind-html="document.relevantInformation | lstring:locale | markdown"></div>
+			<km-value-ml value="document.relevantInformation" locales="locale" km-pre html></km-value-ml>
 		</div>
 
 

--- a/app/directives/formats/views/marine-ebsa.js
+++ b/app/directives/formats/views/marine-ebsa.js
@@ -1,4 +1,4 @@
-define(['app', 'angular', 'lodash', 'text!./marine-ebsa.html', 'leaflet', 'leaflet-directive', 'utilities/km-storage'], function(app, angular, _, template, L){
+define(['app', 'angular', 'lodash', 'text!./marine-ebsa.html', 'leaflet', 'leaflet-directive', 'utilities/km-storage', 'directives/forms/km-value-ml'], function(app, angular, _, template, L){
 
 app.directive('viewMarineEbsa', ['$http', '$q', "IStorage", function ($http, $q, storage) {
 	return {
@@ -22,6 +22,23 @@ app.directive('viewMarineEbsa', ['$http', '$q', "IStorage", function ($http, $q,
 
 			$scope.gisMapLayers = null;
 			$scope.gisMapCenter = null;
+
+			$scope.$watch("document", function(doc) {
+
+				if(!doc) return;
+
+				fixHtml(doc.location);
+				fixHtml(doc.areaIntroducion);
+				fixHtml(doc.areaDescription);
+				fixHtml(doc.areaConditions);
+				fixHtml(doc.areaFeatures);
+				fixHtml(doc.referenceText);
+				fixHtml(doc.relevantInformation);
+
+				if(doc.assessments)
+					doc.assessments.forEach(function(a) { fixHtml(a.justification) })
+			
+			})
 
 			$scope.$watch("document.gisMapCenter", function(gisMapCenter) {
 				$scope.gisMapCenter = angular.fromJson(angular.toJson(gisMapCenter));
@@ -107,4 +124,30 @@ app.directive('viewMarineEbsa', ['$http', '$q', "IStorage", function ($http, $q,
 		}
 	};
 }]);
+
+function fixHtml(ltext) {
+
+	if(!ltext) return ltext;
+
+	if(typeof(ltext) == 'string') 
+		return asHtml(ltext);
+
+	for(var locale in ltext)
+		ltext[locale] = asHtml(ltext[locale]);
+
+	return ltext;
+}
+
+function asHtml(text) {
+
+	if(text && text[0]!='<') {
+		text =  '<p>' + text.replace(/\n/g, '<br>\n')
+							.replace(/\s{2}/g, '&nbsp; ')
+							.replace(/\t/g, '&nbsp; &nbsp; &nbsp; &nbsp; ') +
+				'</p>';
+	}
+
+	return text;
+}
+
 });

--- a/app/directives/forms/km-rich-textbox-custom-controls.js
+++ b/app/directives/forms/km-rich-textbox-custom-controls.js
@@ -16,7 +16,7 @@ define(['app','rangy-core', 'rangy-selectionsave', 'textAngular'], function(app,
             taOptions.toolbar[1].push('uploadCustomImage');
 
             taRegisterTool('uploadCustomFile', {
-                iconclass: "fa fa-files-o",
+                iconclass: "fa fa-cloud-upload",
                 tooltiptext: 'upload file',
                 action: function(){
                     uploadFile(this.$editor());

--- a/app/directives/forms/km-rich-textbox.html
+++ b/app/directives/forms/km-rich-textbox.html
@@ -1,4 +1,4 @@
-﻿<div class="km-rtl">
+<div class="km-rtl">
 	
 	<div ng-repeat="locale in locales" class="input-group input-rich-text" 
 		ng-class="{ 'multiple-languages' : isShowLocale() && !last }"

--- a/app/directives/forms/km-value-ml.html
+++ b/app/directives/forms/km-value-ml.html
@@ -6,7 +6,7 @@
 			ng-class="{'markdown':self.markdown, 'km-pre1':self.kmPre }" ng-bind="self.value|lstring:locale">
 		</div>
 		<div ng-if="html"  >
-			<div ng-bind-html="self.value|lstring:locale|addclear|toTrusted" class="km-value km-value-ml-div km-value-ml-html" 
+			<div ng-bind-html="self.value|lstring:locale|addclear|sanitizeHtml|toTrusted" class="km-value km-value-ml-div km-value-ml-html" 
 			ng-style="{ direction : (self.value|direction:locale)}" 
 			ng-class="{'markdown':self.markdown, 'km-pre1':self.kmPre }"></div>
 			<!-- <div style="clear: both;"></div>	 -->

--- a/app/utilities/km-utilities.js
+++ b/app/utilities/km-utilities.js
@@ -1,4 +1,4 @@
-define(['app', 'lodash', 'linqjs', 'URIjs/URI', "jquery", 'ngCookies', 'scbd-angularjs-filters'], function(app, _, Enumerable, URI, $) { 'use strict';
+define(['app', 'lodash', 'linqjs', 'URIjs/URI', "jquery", 'dompurify', 'ngCookies', 'scbd-angularjs-filters'], function(app, _, Enumerable, URI, $, DOMPurify) { 'use strict';
 
 app.filter('integer', function () {
     return function (number, base, length) {
@@ -23,10 +23,17 @@ app.filter("orderPromiseBy", ["$q", "$filter", function($q, $filter) {
 app.filter("markdown", ["$window", "htmlUtility", function($window, html) {
 	return function(srcText) {
 		if (!$window.marked)//if markdown is not install then return escaped html! to be safe!
-			return '<div style="word-break: break-all; word-wrap: break-word; white-space: pre-wrap;">'+html.encode(srcText)+'</div>';
+			return '<div style="word-wrap: break-word; white-space: pre-wrap;">'+html.encode(srcText)+'</div>';
 		return $window.marked(srcText, { sanitize: true });
 	};
 }]);
+
+app.filter("sanitizeHtml", [function() {
+	return function(html) {
+		return DOMPurify.sanitize(html);
+	};
+}]);
+
 
 app.factory("htmlUtility", function() {
 	return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "superagent": "5.2.1"
       },
       "peerDependencies": {
+        "dompurify": "3.0.1",
         "leaflet": "1.9.3"
       }
     },
@@ -205,6 +206,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
+      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw==",
+      "peer": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -877,6 +884,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dompurify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
+      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw==",
+      "peer": true
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "superagent": "5.2.1"
   },
   "peerDependencies": {
-    "leaflet": "1.9.3"
+    "leaflet": "1.9.3",
+    "dompurify": "3.0.1"
   },
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Enable HTML content for fields
* location
* areaIntroducion
* areaDescription
* areaConditions
* areaFeatures
* referenceText
* relevantInformation
* assessments.justification

Uses of DOMPurify for html sanitization (prevent XSS) 